### PR TITLE
bug reversed blob/clob corrupted

### DIFF
--- a/P_Base64.pkb
+++ b/P_Base64.pkb
@@ -47,7 +47,7 @@ begin
       dbms_lob.createtemporary(vResult, true, dbms_lob.call);
       for i in 0..trunc((vLen - 1) / MAX_ENC_CHUNK_LEN)
       loop
-        vChunk := case when i > 0 then CRLF end || EncodeString(dbms_lob.substr(pIP, MAX_ENC_CHUNK_LEN, i * MAX_ENC_CHUNK_LEN + 1));
+        vChunk := /*case when i > 0 then CRLF end || */EncodeString(dbms_lob.substr(pIP, MAX_ENC_CHUNK_LEN, i * MAX_ENC_CHUNK_LEN + 1));
         dbms_lob.writeappend(vResult, length(vChunk), vChunk);
       end loop;
   end case;
@@ -69,7 +69,7 @@ begin
       dbms_lob.createtemporary(vResult, true, dbms_lob.call);
       for i in 0..trunc((vLen - 1) / MAX_ENC_CHUNK_LEN)
       loop
-        vChunk := case when i > 0 then CRLF end || EncodeRaw(dbms_lob.substr(pIP, MAX_ENC_CHUNK_LEN, i * MAX_ENC_CHUNK_LEN + 1));
+        vChunk := /*case when i > 0 then CRLF end || */EncodeRaw(dbms_lob.substr(pIP, MAX_ENC_CHUNK_LEN, i * MAX_ENC_CHUNK_LEN + 1));
         dbms_lob.writeappend(vResult, length(vChunk), vChunk);
       end loop;
   end case;


### PR DESCRIPTION
p_base64.decodetoblob(p_base64.encodeblob(blobdata)) returns a corrupted blobdata
p_base64.decodetoclob(p_base64.encodeblob(clobdata)) returns a corrupted clobdata

it works fine for small clob/blob but the corruption occurs when the blobdata is bigger than the MAX_ENC_CHUNK_LEN.
I found it fixed the problem after removing the CRLF on every MAX_ENC_CHUNK_LEN output.